### PR TITLE
Enable dot-repeatability after operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ use { "chrisgrieser/nvim-spider" }
 ```
 
 No keybindings are created by default. Below are the mappings to replace the default `w`, `e`, and `b` motions with this plugin's version of them.
+Note that for dot-repeat to work properly, you have to use a `<cmd>` mapping that calls the plugin function, **not** a lua function calling it!
 
 ```lua
 -- Keymaps
-vim.keymap.set({"n", "o", "x"}, "w", "<Plug>(spider-motion-w)", { desc = "Spider-w" })
-vim.keymap.set({"n", "o", "x"}, "e", "<Plug>(spider-motion-e)", { desc = "Spider-e" })
-vim.keymap.set({"n", "o", "x"}, "b", "<Plug>(spider-motion-b)", { desc = "Spider-b" })
-vim.keymap.set({"n", "o", "x"}, "ge", "<Plug>(spider-motion-ge)", { desc = "Spider-ge" })
+vim.keymap.set({"n", "o", "x"}, "w", "<cmd>lua require('spider').motion('w')<CR>", { desc = "Spider-w" })
+vim.keymap.set({"n", "o", "x"}, "e", "<cmd>lua require('spider').motion('e')<CR>", { desc = "Spider-w" })
+vim.keymap.set({"n", "o", "x"}, "b", "<cmd>lua require('spider').motion('b')<CR>", { desc = "Spider-w" })
+vim.keymap.set({"n", "o", "x"}, "ge", "<cmd>lua require('spider').motion('ge')<CR>", { desc = "Spider-w" })
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ No keybindings are created by default. Below are the mappings to replace the def
 
 ```lua
 -- Keymaps
-vim.keymap.set({"n", "o", "x"}, "w", function() require("spider").motion("w") end, { desc = "Spider-w" })
-vim.keymap.set({"n", "o", "x"}, "e", function() require("spider").motion("e") end, { desc = "Spider-e" })
-vim.keymap.set({"n", "o", "x"}, "b", function() require("spider").motion("b") end, { desc = "Spider-b" })
-vim.keymap.set({"n", "o", "x"}, "ge", function() require("spider").motion("ge") end, { desc = "Spider-ge" })
+vim.keymap.set({"n", "o", "x"}, "w", "<Plug>(spider-motion-w)", { desc = "Spider-w" })
+vim.keymap.set({"n", "o", "x"}, "e", "<Plug>(spider-motion-e)", { desc = "Spider-e" })
+vim.keymap.set({"n", "o", "x"}, "b", "<Plug>(spider-motion-b)", { desc = "Spider-b" })
+vim.keymap.set({"n", "o", "x"}, "ge", "<Plug>(spider-motion-ge)", { desc = "Spider-ge" })
 ```
 
 ## Configuration
@@ -90,9 +90,6 @@ require("spider").setup({
 	skipInsignificantPunctuation = true
 })
 ```
-
-## Limitations
-- [ ] Dot repeats when motion has been used as text object. ([Dot-repeat *for text objects* seems a bit more tricky, help is welcome.](https://github.com/chrisgrieser/nvim-various-textobjs/issues/7#issuecomment-1374861900))
 
 ## Credits
 <!-- vale Google.FirstPerson = NO -->

--- a/lua/spider.lua
+++ b/lua/spider.lua
@@ -147,6 +147,14 @@ function M.motion(key)
 	if isOperatorPending and key == "e" then col = col + 1 end
 
 	vim.api.nvim_win_set_cursor(0, { row, col })
+
+-- set plug keymaps
+for _, key in ipairs { "w", "e", "b", "ge" } do
+    vim.keymap.set(
+      "",
+      "<Plug>(spider-motion-" .. key .. ")",
+      "<cmd>lua require('spider').motion('" .. key .. "')<CR>"
+    )
 end
 
 --------------------------------------------------------------------------------

--- a/lua/spider.lua
+++ b/lua/spider.lua
@@ -147,14 +147,6 @@ function M.motion(key)
 	if isOperatorPending and key == "e" then col = col + 1 end
 
 	vim.api.nvim_win_set_cursor(0, { row, col })
-
--- set plug keymaps
-for _, key in ipairs { "w", "e", "b", "ge" } do
-    vim.keymap.set(
-      "",
-      "<Plug>(spider-motion-" .. key .. ")",
-      "<cmd>lua require('spider').motion('" .. key .. "')<CR>"
-    )
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I looked into how to dot-repeat motions and textobjects. It cost me many hours of my life.
But, thanks to @ii14 I found a solution.

It seems that dot repeating an operator-motion combination requires the motion to be a built in motion, or an **ex command**, which somehow moves the cursor.
This means, it is possible to dot-repeat a spider-y `dw` for example, by mapping `w` not to `function() require...` but to `<cmd>lua require...`. That way, that command is used as the motion to be repeated when bound in operator-pending mode.

I put together a little patch that applies this. I hope this helps, and maybe it helps for the problems in nvim-various-textobjs (chrisgrieser/nvim-various-textobjs#7) as well :)