### PR TITLE
Disable skipInsignificantPunctuation in operator-pending mode

### DIFF
--- a/lua/spider.lua
+++ b/lua/spider.lua
@@ -83,7 +83,10 @@ local function getNextPosition(line, col, key)
 		punctAtEnd = "%f[^%s]%p+$",
 		onlyPunct = "^%p+$",
 	}
-	if not skipInsignificantPunc then patterns.punctuation = "%p+" end
+
+	if not (skipInsignificantPunc and not vim.startswith(vim.api.nvim_get_mode().mode, 'no')) then
+    patterns.punctuation = "%p+"
+  end
 
 	-- define motion properties
 	local backwards = (key == "b") or (key == "ge")


### PR DESCRIPTION
Hello!

This is a fix for #9 and #10 for cw, dw, etc.

The option `skipInsignificantPunctuation` is a great thing, but not suitable for operator-pending mode.

Just try it. Everyone can install this plugin from my fork to try.