### PR TITLE
fix: import statement init.lua

### DIFF
--- a/lua/spider/init.lua
+++ b/lua/spider/init.lua
@@ -1,5 +1,5 @@
 local M = {}
-local patternVariants = require("lua.spider.pattern-variants")
+local patternVariants = require("spider.pattern-variants")
 
 --------------------------------------------------------------------------------
 -- CONFIG


### PR DESCRIPTION
There was a bug in require:

```
nvim-spider/lua/spider/init.lua:2: module 'lua.spider.pattern-variants' not found:
```