### PR TITLE
Patterns with $ can match before the cursor position

### DIFF
--- a/lua/spider/init.lua
+++ b/lua/spider/init.lua
@@ -94,7 +94,8 @@ local function firstMatchAfter(line, pattern, endOfWord, offset)
 		if start == nil or endPos == nil then return nil end
 
 		local pos = endOfWord and endPos or start
-		return pos
+		if pos > offset then return pos
+		else return nil end
 	end
 
 	if endOfWord then
@@ -180,8 +181,7 @@ function M.motion(key, motionOpts)
 			local result = getNextPosition(line, offset, key, opts)
 			if result then
 				offset = result
-				local onTheSamePos = (offset == startOffset and row == startRow)
-				if not onTheSamePos then break end
+				break
 			end
 
 			offset = 0


### PR DESCRIPTION
When calculating next match position for patterns that contain $, the result is not checked against the current position. This can lead to cursor moving backwards in some cases:

```lua
local s = require("spider")
s.setup { skipInsignificantPunctuation = true }
vim.keymap.set('n', 'w', function() s.motion('w') end)

-- ,,,,,,,,
--   ^ with the cursor here, press w
```

I originally encountered this issue while trying to add '$' pattern so that the motions stop at the end of the line, and noticed that it didn't work for half of the lines. The [`punctuationAtEnd = "%f[^%s]%p+$"`](https://github.com/chrisgrieser/nvim-spider/blob/828444de406bc7df3b30c8e000ce6f54f0754499/lua/spider/pattern-variants.lua#L26) pattern was matching closing parenthesis at the cursor position, and [`onTheSamePos`](https://github.com/chrisgrieser/nvim-spider/blob/828444de406bc7df3b30c8e000ce6f54f0754499/lua/spider/init.lua#L184) check skipped the current match.


It also looks like the braces in one of the README examples should be different
https://github.com/chrisgrieser/nvim-spider/blob/828444de406bc7df3b30c8e000ce6f54f0754499/README.md#L188-L194

```lua
require("spider").motion("w", {
    customPatterns = {
        patterns = {
            ("%x"):rep(6) .. "+",
        },
        overrideDefault = false,
    }
})
```