### PR TITLE
feat: Improve operator-pending mode behavior

### DIFF
--- a/lua/spider/init.lua
+++ b/lua/spider/init.lua
@@ -196,13 +196,12 @@ function M.motion(key, motionOpts)
 	local mode = vim.api.nvim_get_mode().mode
 	local isOperatorPending = mode == "no" -- [n]ormal & [o]perator, not the word "no"
 	if isOperatorPending then
-		local lastCol = vim.fn.col("$")
 		if key == "e" then
 			offset = offset + 1
 			col = stringFuncs.offset(line, offset) - 1
 		end
 
-		if lastCol - 1 == col then
+		if col == #line then
 			-- HACK columns are end-exclusive, cannot actually target the last
 			-- character in the line without switching to visual mode
 			normal("v")

--- a/lua/spider/operator-pending/init.lua
+++ b/lua/spider/operator-pending/init.lua
@@ -1,0 +1,186 @@
+-- based on https://github.com/vanaigr/motion.nvim at 5511dd91ff4cc51fceca4afdab92705ca9442c55
+
+local vim = vim
+
+local u = require("spider.operator-pending.util")
+
+local M = {}
+
+M.util = u
+
+--- Modifies endpoints from range [`p1`, `p2`) or [`p2`, `p1`)
+--- for charwise visual selection. Positions are (1, 0) indexed.
+---
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param context table? Context from `createContext()`
+--- @return boolean: Whether the selection can be created.
+function M.rangeToVisual(p1, p2, context)
+    if not context then context = u.createContext() end
+    local lines = context.lines
+    local linesCount = context.linesCount
+
+    u.clampPos(p1, context)
+    u.clampPos(p2, context)
+
+    local sel = context.selection
+    if sel == 'exclusive' then
+        return not u.isSameChar(p1, p2, context)
+    end
+
+    local posF, posL
+    if u.posLt(p1, p2) then posF, posL = p1, p2
+    else posF, posL = p2, p1 end
+
+    u.moveToCur(posF, context)
+    u.moveToPrev(posL, context)
+
+    -- Note: old + virtualedit ~= inclusive  (if old and ends in EOL, it is ignored)
+    if sel == 'inclusive' or (sel == 'old' and context.virtualedit) then
+        return not u.posLt(posL, posF)
+    end
+
+    assert(sel == 'old')
+
+    if posF[2] > 0 and posF[2] >= #lines[posF[1]] then
+        if posF[1] >= linesCount then return false end
+        posF[1] = posF[1] + 1
+        posF[2] = 0
+    end
+
+    if posL[2] > 0 and posL[2] >= #lines[posL[1]] then
+        posL[2] = #lines[posL[1]] - 1
+    end
+
+    return not u.posLt(posL, posF)
+end
+
+--- Modifies endpoints from range [`p1`, `p2`] or [`p2`, `p1`]
+--- for charwise visual selection. Positions are (1, 0) indexed.
+---
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param context table? Context from `createContext()`
+---
+--- @return boolean: Whether the selection can be created.
+function M.rangeInclusiveToVisual(p1, p2, context)
+    if not context then context = u.createContext() end
+    local lines = context.lines
+    local linesCount = context.linesCount
+
+    u.clampPos(p1, context)
+    u.clampPos(p2, context)
+
+    local sel = context.selection
+    if sel == 'inclusive' or (sel == 'old' and context.virtualedit) then
+        return true
+    end
+
+    local posF, posL
+    if u.posLt(p1, p2) then posF, posL = p1, p2
+    else posF, posL = p2, p1 end
+
+    if sel == 'exclusive' then
+        u.moveToNext(posL, context)
+        return true
+    end
+
+    assert(sel == 'old')
+
+    if posF[2] > 0 and posF[2] >= #lines[posF[1]] then
+        if posF[1] >= linesCount then return false end -- last EOL in file
+        posF[1] = posF[1] + 1
+        posF[2] = 0
+    end
+
+    if posL[2] > 0 and posL[2] >= #lines[posL[1]] then
+        posL[2] = #lines[posL[1]] - 1
+    end
+
+    return not u.posLt(posL, posF)
+end
+
+--- Modifies endpoints `p1` and `p2` from range for a text object. Positions are (1, 0) indexed.
+---
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param opts { mode: "v" | "V" | "", inclusive: boolean, context: table }
+---
+--- @return string | nil: which visual mode to use when setting selection. nil if not possible to select
+function M.calcEndpoints(p1, p2, opts)
+    local mode = opts.mode
+    local incl = opts.inclusive
+    local context = opts.context
+    if mode == 'v' then
+        if incl then
+            if M.rangeInclusiveToVisual(p1, p2, context) then return 'v' end
+        else
+            if M.rangeToVisual(p1, p2, context) then return 'v' end
+        end
+    elseif mode == 'V' then
+        u.clampPos(p1, context)
+        u.clampPos(p2, context)
+        return 'V'
+    else
+        assert(mode == '')
+
+        u.clampPos(p1, context)
+        u.clampPos(p2, context)
+
+        local sel = context.selection
+        if incl then
+            if sel == 'inclusive' or (sel == 'old' and context.blockwiseVirtualedit) then
+                return ''
+            elseif sel == 'old' then
+                local lines = context.lines
+                if (p1[2] == 0 or p1[2] < #lines[p1[1]])
+                    and (p2[2] == 0 or p2[2] < #lines[p2[1]])
+                then
+                    return ''
+                end
+            end
+        else
+            if sel == 'exclusive' then
+                if not u.isSameChar(p1, p2, context) then return '' end
+            end
+        end
+    end
+end
+
+--- Sets the range defined by `p1` and `p2` as positions for a custom text object.
+--- (Default: charwise end-exclusive). `inclusive` only affects the column value,
+--- and only in charwise and blockwise modes. Handles forced motion.
+--- Positions are (1, 0) indexed, both are modified.
+---
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param opts { mode: nil | "v" | "V" | "", inclusive: boolean?, context: table? }?
+--- @return boolean: False if couldn't set the positions.
+function M.setEndpoints(p1, p2, opts)
+    local context = opts and opts.context or u.createContext()
+
+    local curMode = vim.fn.mode(true)
+
+    -- note: forced motion doesn't affect text objects defined through
+    -- visual selection (apart from broken <C-V>). Handle it ourselves.
+    local mode = opts and opts.mode or 'v'
+    local inclusive = opts and opts.inclusive and true or false
+    if curMode == 'nov' then
+        if mode == 'v' then inclusive = not inclusive end
+        mode = 'v'
+    elseif curMode == 'noV' then
+        mode = 'V'
+    elseif curMode == 'no' then
+        mode = ''
+    end
+
+    local resMode = M.calcEndpoints(p1, p2, {
+        mode = mode, inclusive = inclusive, context = context,
+    })
+    if not resMode then return false end
+
+    u.visualStart(p1, p2, resMode)
+    return true
+end
+
+return M

--- a/lua/spider/operator-pending/util.lua
+++ b/lua/spider/operator-pending/util.lua
@@ -1,0 +1,223 @@
+local vim = vim
+
+local Lines = {
+    __index = function(tab, k)
+        local line = vim.api.nvim_buf_get_lines(0, k-1, k, true)[1]
+        rawset(tab, k, line)
+        return line
+    end,
+}
+local Context = {
+    __index = function(tab, k)
+        if k == '__virtualedit' then
+            local v = vim.split(
+                vim.api.nvim_get_option_value('virtualedit', {}),
+                ',', { plain = true }
+            )
+            rawset(tab, k, v)
+            return v
+        elseif k == 'virtualedit' then
+            local ve = tab.__virtualedit
+
+            local c = false
+            for _, v in ipairs(ve) do
+                if v == 'all' or v == 'onemore' then
+                    c = true
+                    break
+                end
+            end
+
+            rawset(tab, k, c)
+            return c
+        elseif k == 'blockwise_virtualedit' then
+            local ve = tab.__virtualedit
+
+            local c = false
+            for _, v in ipairs(ve) do
+                if v == 'all' or v == 'onemore' or v == 'block' then
+                    c = true
+                    break
+                end
+            end
+
+            rawset(tab, k, c)
+            return c
+        elseif k == 'selection' then
+            local v = vim.api.nvim_get_option_value('selection', {})
+            rawset(tab, k, v)
+            return v
+        end
+    end
+}
+
+local M = {}
+
+--- @return table
+function M.createContext()
+    return setmetatable({
+        lines = setmetatable({}, Lines),
+        linesCount = vim.api.nvim_buf_line_count(0),
+    }, Context)
+end
+
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param mode nil | "v" | "V" | "" Visual mode, default "v"
+function M.visualStart(p1, p2, mode)
+    if not mode then mode = 'v'
+    else assert(mode == 'v' or mode == 'V' or mode == '') end
+    -- Enter visual first! Positions might be valid only in visual
+    vim.cmd([[noautocmd normal! ]]..mode)
+    vim.api.nvim_win_set_cursor(0, p1)
+    vim.cmd([[noautocmd normal! o]])
+    vim.api.nvim_win_set_cursor(0, p2)
+end
+
+--- Modifies given position to be clamped to the buffer and line length.
+---
+--- @param pos table<integer, integer>
+--- @param context table Context from `createContext()`
+--- @return table<integer, integer>: `pos`
+function M.clampPos(pos, context)
+    local linesCount = context.linesCount
+
+    if pos[1] < 1 then
+        pos[1] = 1
+        pos[2] = 0
+    elseif pos[1] > linesCount then
+        pos[1] = linesCount
+        pos[2] = #context.lines[linesCount]
+    elseif pos[2] < 0 then
+        pos[2] = 0
+    else
+        pos[2] = math.min(pos[2], #context.lines[pos[1]])
+    end
+
+    return pos
+end
+
+
+--- Checks whether `a` < `b`.
+--- @param a table<integer, integer>
+--- @param b table<integer, integer>
+--- @return boolean
+function M.posLt(a, b)
+    return a[1] < b[1] or (a[1] == b[1] and a[2] < b[2])
+end
+
+--- Checks whether positions `a` and `b` are equal.
+--- @param a table<integer, integer>
+--- @param b table<integer, integer>
+--- @return boolean
+function M.posEq(a, b)
+    return a[1] == b[1] and a[2] == b[2]
+end
+
+--- Checks whether given 2 positions are on the same character.
+--- Positions are (1, 0) indexed, clamped.
+---
+--- @param p1 table<integer, integer>
+--- @param p2 table<integer, integer>
+--- @param context table Context from `createContext()`
+--- @return boolean
+function M.isSameChar(p1, p2, context)
+    if p1[1] ~= p2[1] then return false end
+    if p1[2] == p2[2] then return true end
+    local line = context.lines[p1[1]]
+    return vim.fn.charidx(line, p1[2]) == vim.fn.charidx(line, p2[2])
+end
+
+--- Modifies `pos` to point to the first byte of the character that contains it.
+--- Composing characters are considered a part of one character.
+---
+--- @param pos table<integer, integer> (1, 0) indexed clamped position
+--- @param context table Context from `createContext()`
+--- @return table<integer, integer>: `pos`
+function M.moveToCur(pos, context)
+    local lines = context.lines
+    local line = lines[pos[1]]
+
+    local ci = vim.fn.charidx(line, pos[2])
+    if ci < 0 then
+        pos[2] = #line
+    else
+        local bi = vim.fn.byteidx(line, ci)
+        assert(bi >= 0)
+        pos[2] = bi
+    end
+
+    return pos
+end
+
+--- Modifies `pos` to point to the first byte of the next character.
+--- Composing characters are considered a part of one character.
+---
+--- @param pos table<integer, integer> (1, 0) indexed clamped position
+--- @param context table Context from `createContext()`
+--- @return table<integer, integer>: `pos`
+function M.moveToNext(pos, context)
+    local lines = context.lines
+    local linesCount = context.linesCount
+    local line = lines[pos[1]]
+
+    if pos[2] == #line then
+        if pos[1] < linesCount then
+            pos[1] = pos[1] + 1
+            pos[2] = 0
+        end
+        return pos
+    end
+
+    local ci = vim.fn.charidx(line, pos[2])
+    assert(ci >= 0)
+
+    local bi = vim.fn.byteidx(line, ci + 1)
+    assert(bi >= 0)
+    pos[2] = bi
+    return pos
+end
+
+--- Modifies `pos` to point to the first byte of the previous character.
+--- Composing characters are considered a part of one character.
+---
+--- @param pos table<integer, integer> (1, 0) indexed clamped position
+--- @param context table Context from `createContext()`
+--- @return table<integer, integer>: `pos`
+function M.moveToPrev(pos, context)
+    local lines = context.lines
+    local line = lines[pos[1]]
+
+    -- So many cases just bc charidx(line, #line) is not #chars in line...
+    -- Even though corresponding is true for byteidx...
+    if #line == 0 then
+        if pos[1] > 1 then
+            pos[1] = pos[1] - 1
+            pos[2] = #lines[pos[1]]
+        end
+        return pos
+    elseif pos[2] == #line then
+        local ci = vim.fn.charidx(line, #line - 1)
+        assert(ci >= 0)
+        local bi = vim.fn.byteidx(line, ci)
+        assert(bi >= 0)
+        pos[2] = bi
+        return pos
+    end
+
+    local ci = vim.fn.charidx(line, pos[2])
+    assert(ci >= 0)
+    if ci == 0 then
+        if pos[1] > 1 then
+            pos[1] = pos[1] - 1
+            pos[2] = #lines[pos[1]]
+        end
+    else
+        local bi = vim.fn.byteidx(line, ci - 1)
+        assert(bi >= 0)
+        pos[2] = bi
+    end
+
+    return pos
+end
+
+return M


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the `README.md`.

---

Currently, the plugin switches to visual mode when selecting the last character in the line in operator-pending mode. Since `selection` option affects whether the last character in visual mode is included, setting `selection=exclusive` breaks the motion:

```lua
vim.cmd([[set selection=exclusive]])
vim.keymap.set('o', 'e', function() require('spider').motion('e') end)
```

For this text (`|a|` means that the cursor is on the character 'a'):

```
|a|bc
```

typing `de` would not delete the last character 'c'.

This PR fixes this; `de` deletes from the current position to the end of the word regardless of whether `selection` is `inclusive` or `exclusive`.

---

Using `v` to change inclusiveness also doesn't affect `e`, i.e. `de` is equivalent to `dve`. This PR makes `dve` exclusive (since `de` is inclusive), i.e. the end character is not selected.

---

I wrote a [post](https://www.reddit.com/r/neovim/comments/1d14rdy/defining_motions_correctly) describing various quirks of how motions work in (neo)vim. One of them is that if the end position of an exclusive charwise motion can never be at the start of the line, i.e. currently, for this text:

```
  a|b|c
def
```

typing `dw` would not delete the EOL between the 2 lines:

```
  |a|
def
```

But if the cursor is moved one char to the left:

```
  |a|bc
def
```

then `dw` would delete the entire first line (including indentation before the cursor), since the motion is updated to be linewise:

```
|d|ef
```

&nbsp;
Both of these are different from the base case (both words on the same line):

```
  a|b|c def
```

where `dw` results in this:

```
  a|d|ef
```

&nbsp;
This PR makes `dw` in the first case result in this:

```
  a|d|ef
```

and in the second case:

```
  |d|ef
```

I.e. the `w` always acts as the base case, even if the end position happens to be at the start of the line.

---

I wrote [a plugin](https://github.com/vanaigr/motion.nvim/tree/main) that handles these cases and would like to know what would be the best way to integrate it into this plugin. Its code can just copied into the project, or It can be added to the config as an optional dependency.