### PR TITLE
fix(utf8): fix field access error on spider moves

### DIFF
--- a/lua/spider/utf8-support.lua
+++ b/lua/spider/utf8-support.lua
@@ -23,7 +23,7 @@ else
 	for name, _ in pairs(originalLuaStringFuncs) do
 		if utf8[name] then M.stringFuncs[name] = utf8[name] end
 	end
-	M.stringFuncs.init_pos = function(s, col)
+	M.stringFuncs.initPos = function(s, col)
 		local offset = 1
 		for p, _ in utf8.codes(s) do
 			if p > col then break end


### PR DESCRIPTION
## Motivation

First of all, I want to say thank you for making this wonderful project!

However, after a recent refactoring (https://github.com/chrisgrieser/nvim-spider/commit/1876e83b4a72a4d12df328f9b631d87c93eea614) adding an extra `utf8_support.lua` source file, if I enable UTF8 support when using `spider`, any motion (even a simple `w`) will cause the following error:

```console
E5108: Error executing lua ...l/.local/share/nvim/lazy/nvim-spider/lua/spider/init.lua:45: attempt to call field 
'initPos' (a nil value)                                                                                          
stack traceback:                                                                                                 
        ...l/.local/share/nvim/lazy/nvim-spider/lua/spider/init.lua:45: in function 'motion'                     
        [string ":lua"]:1: in main chunk 
```

As it turns out, this is caused by a simple typo. I've tried the fix locally and it seems to work pretty well.

## Checklist
- [x] Used only camelCase variable names.
- [x] ~~If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).~~


